### PR TITLE
Add support for filtering what rows are included in #to_csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ csv = HoneyFormat::CSV.new(csv_string)
 csv.to_csv(columns: [:id, :country]) # => "id,country\nburen,Sweden\n"
 ```
 
+Output a subset of rows to CSV
+```ruby
+csv_string = "Name, Country\nburen,Sweden\njacob,Denmark"
+csv = HoneyFormat::CSV.new(csv_string)
+csv.to_csv { |row| row.country == 'Sweden' } # => "name,country\nburen,Sweden\n"
+```
+
 You can of course set the delimiter
 ```ruby
 HoneyFormat::CSV.new(csv_string, delimiter: ';')

--- a/lib/honey_format/convert_header_value.rb
+++ b/lib/honey_format/convert_header_value.rb
@@ -16,6 +16,7 @@ module HoneyFormat
     # Returns converted value and mutates the argument.
     # @return [Symbol] the cleaned header column.
     # @param [String] column the string to be cleaned.
+    # @param [Integer] column index.
     # @example Convert simple header
     #     ConvertHeaderValue.call("  User name ") #=> "user_name"
     # @example Convert complex header

--- a/lib/honey_format/csv.rb
+++ b/lib/honey_format/csv.rb
@@ -7,9 +7,11 @@ module HoneyFormat
   # Represents CSV.
   class CSV
     # @return [CSV] a new instance of CSV.
-    # @param [String] csv string.
-    # @param [Array<Symbol>] valid_columns valid array of symbols representing valid columns if empty all will be considered valid.
-    # @param [Array<String>] header optional argument for CSV header.
+    # @param [String] csv the CSV string
+    # @param [String] delimiter the CSV delimiter
+    # @param [Array<String>] header optional argument that represents CSV header, required if the CSV file lacks a header row.
+    # @param [Array<Symbol>] valid_columns array of symbols representing valid columns, if empty all will be considered valid.
+    # @param [#call] header_converter converts header columns.
     # @param [#call] row_builder will be called for each parsed row.
     # @raise [HeaderError] super class of errors raised when there is a CSV header error.
     # @raise [MissingHeaderError] raised when header is missing (empty or nil).
@@ -38,13 +40,12 @@ module HoneyFormat
     end
 
     # @return [Array] of rows.
-    # @raise [InvalidRowLengthError] raised when there are more row elements longer than columns
     def rows
       @rows
     end
 
     # @yield [row] The given block will be passed for every row.
-    # @yieldparam [Row] a column in the CSV header.
+    # @yieldparam [Row] row in the CSV.
     # @return [Enumerator] If no block is given, an enumerator object will be returned.
     def each_row
       return rows.each unless block_given?
@@ -54,8 +55,15 @@ module HoneyFormat
 
     # Convert CSV object as CSV-string.
     # @param columns [Array<Symbol>, Set<Symbol>, NilClass] the columns to output, nil means all columns (default: nil)
-    # @yieldparam [Row] each row - return truthy if you want the row to be included in the output
+    # @yield [row] The given block will be passed for every row - return truthy if you want the row to be included in the output
+    # @yieldparam [Row] row
     # @return [String] CSV-string representation.
+    # @example with selected columns
+    #   csv.to_csv(columns: [:id, :country])
+    # @example with selected rows
+    #   csv.to_csv { |row| row.country == 'Sweden' }
+    # @example with both selected columns and rows
+    #   csv.to_csv(columns: [:id, :country]) { |row| row.country == 'Sweden' }
     def to_csv(columns: nil, &block)
       @header.to_csv(columns: columns) + @rows.to_csv(columns: columns, &block)
     end

--- a/lib/honey_format/csv.rb
+++ b/lib/honey_format/csv.rb
@@ -44,7 +44,7 @@ module HoneyFormat
     end
 
     # @yield [row] The given block will be passed for every row.
-    # @yieldparam [Row] a colmn in the CSV header.
+    # @yieldparam [Row] a column in the CSV header.
     # @return [Enumerator] If no block is given, an enumerator object will be returned.
     def each_row
       return rows.each unless block_given?

--- a/lib/honey_format/csv.rb
+++ b/lib/honey_format/csv.rb
@@ -53,9 +53,11 @@ module HoneyFormat
     end
 
     # Convert CSV object as CSV-string.
+    # @param columns [Array<Symbol>, Set<Symbol>, NilClass] the columns to output, nil means all columns (default: nil)
+    # @yieldparam [Row] each row - return truthy if you want the row to be included in the output
     # @return [String] CSV-string representation.
-    def to_csv(columns: nil)
-      @header.to_csv(columns: columns) + @rows.to_csv(columns: columns)
+    def to_csv(columns: nil, &block)
+      @header.to_csv(columns: columns) + @rows.to_csv(columns: columns, &block)
     end
   end
 end

--- a/lib/honey_format/header.rb
+++ b/lib/honey_format/header.rb
@@ -32,7 +32,7 @@ module HoneyFormat
     end
 
     # @yield [row] The given block will be passed for every column.
-    # @yieldparam [Row] a colmn in the CSV header.
+    # @yieldparam [Row] a column in the CSV header.
     # @return [Enumerator]
     #   If no block is given, an enumerator object will be returned.
     def each(&block)

--- a/lib/honey_format/header.rb
+++ b/lib/honey_format/header.rb
@@ -10,6 +10,7 @@ module HoneyFormat
     # @param [Array<String>] header array of strings.
     # @param [Array<Symbol, String>] valid array representing the valid columns, if empty all columns will be considered valid.
     # @param converter [#call] header converter that implements a #call method that takes one column (string) argument.
+    # @raise [HeaderError] super class of errors raised when there is a CSV header error.
     # @raise [MissingHeaderColumnError] raised when header is missing
     # @raise [UnknownHeaderColumnError] raised when column is not in valid list.
     # @example Instantiate a header with a customer converter

--- a/lib/honey_format/row.rb
+++ b/lib/honey_format/row.rb
@@ -7,7 +7,9 @@ module HoneyFormat
     # @return [Row] a new instance of Row.
     # @param [Array] columns an array of symbols.
     # @param builder [#call, #to_csv] optional row builder
+    # @raise [RowError] super class of errors raised when there is a row error.
     # @raise [EmptyRowColumnsError] raised when there are no columns.
+    # @raise [InvalidRowLengthError] raised when row has more columns than header columns.
     # @example Create new row
     #     Row.new!([:id])
     def initialize(columns, builder: nil)
@@ -22,7 +24,7 @@ module HoneyFormat
     end
 
     # Returns a Struct.
-    # @return [Struct] a new instance of Row.
+    # @return [Object] a new instance of built row.
     # @param row [Array] the row array.
     # @raise [InvalidRowLengthError] raised when there are more row elements longer than columns
     # @example Build new row

--- a/lib/honey_format/row_builder.rb
+++ b/lib/honey_format/row_builder.rb
@@ -8,6 +8,7 @@ module HoneyFormat
     end
 
     # Represent row as CSV
+    # @param columns [Array<Symbol>, Set<Symbol>, NilClass] the columns to output, nil means all columns (default: nil)
     # @return [String] CSV-string representation.
     def to_csv(columns: nil)
       attributes = members

--- a/lib/honey_format/rows.rb
+++ b/lib/honey_format/rows.rb
@@ -35,11 +35,19 @@ module HoneyFormat
     end
     alias_method :size, :length
 
+    # @param columns [Array<Symbol>, Set<Symbol>, NilClass] the columns to output, nil means all columns (default: nil)
+    # @yieldparam [Row] each row - return truthy if you want the row to be included in the output
     # @return [String] CSV-string representation.
-    def to_csv(columns: nil)
+    def to_csv(columns: nil, &block)
       # Convert columns to Set for performance
       columns = Set.new(columns) if columns
-      to_a.map { |row| row.to_csv(columns: columns) }.join
+      csv_rows = []
+      each do |row|
+        if !block || block.call(row)
+          csv_rows << row.to_csv(columns: columns)
+        end
+      end
+      csv_rows.join
     end
 
     private

--- a/lib/honey_format/rows.rb
+++ b/lib/honey_format/rows.rb
@@ -10,6 +10,9 @@ module HoneyFormat
     # @return [Rows] new instance of Rows.
     # @param [Array] rows the array of rows.
     # @param [Array] columns the array of column symbols.
+    # @raise [RowError] super class of errors raised when there is a row error.
+    # @raise [EmptyRowColumnsError] raised when there are no columns.
+    # @raise [InvalidRowLengthError] raised when row has more columns than header columns.
     def initialize(rows, columns, builder: nil)
       @rows = prepare_rows(Row.new(columns, builder: builder), rows)
     end
@@ -36,8 +39,15 @@ module HoneyFormat
     alias_method :size, :length
 
     # @param columns [Array<Symbol>, Set<Symbol>, NilClass] the columns to output, nil means all columns (default: nil)
-    # @yieldparam [Row] each row - return truthy if you want the row to be included in the output
+    # @yield [row] each row - return truthy if you want the row to be included in the output
+    # @yieldparam [Row] row
     # @return [String] CSV-string representation.
+    # @example with selected columns
+    #   rows.to_csv(columns: [:id, :country])
+    # @example with selected rows
+    #   rows.to_csv { |row| row.country == 'Sweden' }
+    # @example with both selected columns and rows
+    #   csv.to_csv(columns: [:id, :country]) { |row| row.country == 'Sweden' }
     def to_csv(columns: nil, &block)
       # Convert columns to Set for performance
       columns = Set.new(columns) if columns

--- a/spec/honey_format/csv_spec.rb
+++ b/spec/honey_format/csv_spec.rb
@@ -125,6 +125,12 @@ let(:diabolical_cols) {
       expect(csv.to_csv(columns: [:username])).to eq("username\nburen\n")
     end
 
+    it 'returns a CSV-string with selected rows' do
+      csv_string = "1,buren\n2,jacob"
+      csv = described_class.new(csv_string, header: ['Id', 'Username'])
+      expect(csv.to_csv { |row| row.username == 'buren' }).to eq("id,username\n1,buren\n")
+    end
+
     it 'returns a valid CSV-string even if values needs special quoting' do
       csv_string = '1,"jacob ""buren"" burenstam"'
       csv = described_class.new(csv_string, header: ['Id', 'Username'])

--- a/spec/honey_format/rows_spec.rb
+++ b/spec/honey_format/rows_spec.rb
@@ -36,10 +36,17 @@ describe HoneyFormat::Rows do
     end
 
     it 'returns the rows as a CSV-string with selected columns' do
-      matrix = [%w[name age country], %w[buren 28 Sweden]]
+      matrix = [%w[buren 28 Sweden]]
       rows = described_class.new(matrix, %i[name age country])
 
-      expect(rows.to_csv(columns: %i[country age])).to eq("age,country\n28,Sweden\n")
+      expect(rows.to_csv(columns: %i[country age])).to eq("28,Sweden\n")
+    end
+
+    it 'returns the rows as a CSV-string with selected rows' do
+      matrix = [%w[buren Sweden], %w[jacob Denmark]]
+      rows = described_class.new(matrix, %i[name country])
+
+      expect(rows.to_csv { |row| row.country == 'Sweden' }).to eq("buren,Sweden\n")
     end
   end
 


### PR DESCRIPTION
Example
```ruby
csv_string = <<~CSV
name,age,country
buren,28,Sweden
jacob,28,Denmark
CSV

csv = HoneyFormat::CSV.new(csv_string)
csv.to_csv(columns: %i[age country]) { |row| row.country == 'Sweden' }
# => "age,country\n28,Sweden\n"
