### PR TITLE
Additional converters

### DIFF
--- a/lib/honey_format/value_converter.rb
+++ b/lib/honey_format/value_converter.rb
@@ -1,6 +1,7 @@
 require 'date'
 require 'time'
 require 'set'
+require 'digest'
 
 require 'honey_format/header_column_converter'
 
@@ -25,6 +26,7 @@ module HoneyFormat
       symbol: proc { |v| v&.to_sym },
       downcase: proc { |v| v&.downcase },
       upcase: proc { |v| v&.upcase },
+      md5: proc { |v| Digest::MD5.hexdigest(v) if v },
       nil: proc {},
       header_column: HeaderColumnConverter,
     }.freeze

--- a/spec/honey_format/value_converter_spec.rb
+++ b/spec/honey_format/value_converter_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe HoneyFormat::ValueConverter do
   describe "#types" do
     it 'returns the register types' do
       expected = %i[
-        decimal! integer! date! datetime! symbol! downcase! upcase!
-        decimal integer date datetime symbol downcase upcase md5 nil
+        decimal! integer! date! datetime! symbol! downcase! upcase! boolean!
+        decimal integer date datetime symbol downcase upcase boolean md5 nil
         header_column
       ]
       expect(described_class.new.types).to eq(expected)
@@ -46,6 +46,53 @@ RSpec.describe HoneyFormat::ValueConverter do
       it "returns nil if value can't be converted" do
         value = described_class.new.call('aa', :integer)
         expect(value).to be_nil
+      end
+    end
+
+    describe "boolean! type" do
+      %w[t T 1 y Y true TRUE].each do |input|
+        it "can convert #{input} to true" do
+          value = described_class.new.call(input, :boolean!)
+          expect(value).to eq(true)
+        end
+      end
+
+      %w[f F 0 n N false FALSE].each do |input|
+        it "can convert #{input} to false" do
+          value = described_class.new.call(input, :boolean!)
+          expect(value).to eq(false)
+        end
+      end
+
+      [nil, 'asd', '2', '', '11', '00'].each do |input|
+        it "raises ArgumentError if type can't be converted" do
+          expect do
+            described_class.new.call(input, :boolean!)
+          end.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    describe "boolean type" do
+      %w[t T 1 y Y true TRUE].each do |input|
+        it "can convert #{input} to true" do
+          value = described_class.new.call(input, :boolean)
+          expect(value).to eq(true)
+        end
+      end
+
+      %w[f F 0 n N false FALSE].each do |input|
+        it "can convert #{input} to false" do
+          value = described_class.new.call(input, :boolean)
+          expect(value).to eq(false)
+        end
+      end
+
+      [nil, 'asd', '2', '', '11', '00'].each do |input|
+        it "returns nil for #{input}" do
+          value = described_class.new.call(input, :boolean)
+          expect(value).to be_nil
+        end
       end
     end
 

--- a/spec/honey_format/value_converter_spec.rb
+++ b/spec/honey_format/value_converter_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe HoneyFormat::ValueConverter do
     it 'returns the register types' do
       expected = %i[
         decimal! integer! date! datetime! symbol! downcase! upcase!
-        decimal integer date datetime symbol downcase upcase nil
+        decimal integer date datetime symbol downcase upcase md5 nil
         header_column
       ]
       expect(described_class.new.types).to eq(expected)
@@ -221,6 +221,23 @@ RSpec.describe HoneyFormat::ValueConverter do
       it 'converts value to nil' do
         value = described_class.new.call('buren', :nil)
         expect(value).to be_nil
+      end
+    end
+
+    describe 'md5 type' do
+      it 'return nil when given nil' do
+        value = described_class.new.call(nil, :md5)
+        expect(value).to be_nil
+      end
+
+      it 'converts value to MD5' do
+        converter = described_class.new
+        value = converter.call('buren', :md5)
+        value1 = converter.call('buren', :md5)
+
+        expect(value).not_to eq('buren')
+        expect(value.length).to eq(32)
+        expect(value).to eq(value1)
       end
     end
 


### PR DESCRIPTION
- MD5 converter
- Boolean converter
  + _truthy values_: `%w[t T 1 y Y true TRUE]`
  + _falsy values_:  `%w[f F 0 n N false FALSE]`

_Boolean example_:

```ruby
csv_string = "Id,newsletter\n1,y"
type_map = { newsletter: :boolean }
csv = HoneyFormat::CSV.new(csv_string, type_map: type_map)
csv.rows.first.newsletter # => true
```

_MD5 example_:

```ruby
csv_string = "Id,name\n1,buren"
type_map = { name: :md5 }
csv = HoneyFormat::CSV.new(csv_string, type_map: type_map)
csv.rows.first.name # => "a586591b04ed0c660e93eda0a9489d54"
```