### PR TITLE
Add support for CSV skip lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,23 @@ You can see all [available errors here](https://www.rubydoc.info/gems/honey_form
 
 If you want to see more usage examples check out the [`examples/`](https://github.com/buren/honey_format/tree/master/examples) and [`spec/`](https://github.com/buren/honey_format/tree/master/spec) directories.
 
+__Skip lines__
+
+> Skip comments and/or other unwanted lines from being parsed.
+
+```ruby
+csv_string = <<~CSV
+Id,Username
+1,buren
+# comment
+2,jacob
+CSV
+regexp = %r{\A#} # Match all lines that start with "#"
+csv = HoneyFormat::CSV.new(csv_string, skip_lines: regexp)
+csv.rows.length # => 2
+```
+
+
 ## CLI
 
 > Perfect when you want to get something simple done quickly.

--- a/README.md
+++ b/README.md
@@ -304,13 +304,14 @@ csv.rows.length # => 2
 > Perfect when you want to get something simple done quickly.
 
 ```
-Usage: honey_format [file.csv] [options]
+Usage: honey_format [options] <file.csv>
         --csv=input.csv              CSV file
-        --[no-]header-only           Print only the header
-        --[no-]rows-only             Print only the rows
-        --columns=id,name            Select columns.
+        --columns=id,name            Select columns
         --output=output.csv          CSV output (STDOUT otherwise)
         --delimiter=,                CSV delimiter (default: ,)
+        --skip-lines=,               Skip lines that match this pattern
+        --[no-]header-only           Print only the header
+        --[no-]rows-only             Print only the rows
     -h, --help                       How to use
         --version                    Show version
 ```

--- a/exe/honey_format
+++ b/exe/honey_format
@@ -11,7 +11,11 @@ options = cli.options
 
 input_path = options[:input_path] || raise(ArgumentError, 'input path required')
 csv_input = File.read(input_path)
-csv = HoneyFormat::CSV.new(csv_input, delimiter: options[:delimiter])
+csv = HoneyFormat::CSV.new(
+  csv_input,
+  delimiter: options[:delimiter],
+  skip_lines: options[:skip_lines]
+)
 
 csv_part = if options[:header_only]
              csv.header

--- a/lib/honey_format/cli/cli.rb
+++ b/lib/honey_format/cli/cli.rb
@@ -29,6 +29,7 @@ module HoneyFormat
       delimiter = ','
       header_only = false
       rows_only = false
+      skip_lines = nil
 
       OptionParser.new do |parser|
         parser.banner = "Usage: honey_format [options] <file.csv>"
@@ -48,6 +49,10 @@ module HoneyFormat
 
         parser.on("--delimiter=,", String, "CSV delimiter (default: ,)") do |value|
           delimiter = value
+        end
+
+        parser.on("--skip-lines=,", String, "Skip lines that match this pattern") do |value|
+          skip_lines = value
         end
 
         parser.on("--[no-]header-only", "Print only the header") do |value|
@@ -85,6 +90,7 @@ module HoneyFormat
         delimiter: delimiter,
         header_only: header_only,
         rows_only: rows_only,
+        skip_lines: skip_lines
       }
     end
   end

--- a/lib/honey_format/csv.rb
+++ b/lib/honey_format/csv.rb
@@ -17,6 +17,7 @@ module HoneyFormat
     # @param [#call] header_converter converts header columns.
     # @param [#call] row_builder will be called for each parsed row.
     # @param type_map [Hash] map of column_name => type conversion to perform.
+    # @param skip_lines [Regexp, String] Regexp for determining wheter a line is a comment. See CSV skip_lines option.
     # @raise [HeaderError] super class of errors raised when there is a CSV header error.
     # @raise [MissingHeaderError] raised when header is missing (empty or nil).
     # @raise [MissingHeaderColumnError] raised when header column is missing.
@@ -48,14 +49,16 @@ module HoneyFormat
       header: nil,
       header_converter: HoneyFormat.header_converter,
       row_builder: nil,
-      type_map: {}
+      type_map: {},
+      skip_lines: nil
     )
       csv = ::CSV.parse(
         csv,
         col_sep: delimiter,
         row_sep: row_delimiter,
         quote_char: quote_character,
-        skip_blanks: true
+        skip_blanks: true,
+        skip_lines: skip_lines
       )
       super(
         csv,

--- a/spec/honey_format/cli/cli_spec.rb
+++ b/spec/honey_format/cli/cli_spec.rb
@@ -56,7 +56,8 @@ RSpec.describe HoneyFormat::CLI do
         output_path: nil,
         delimiter: ",",
         header_only: false,
-        rows_only: false
+        rows_only: false,
+        skip_lines: nil
       }
       expect(cli.options).to eq(expected)
     end
@@ -73,7 +74,8 @@ RSpec.describe HoneyFormat::CLI do
         output_path: nil,
         delimiter: ",",
         header_only: false,
-        rows_only: false
+        rows_only: false,
+        skip_lines: nil
       }
       expect(cli.options).to eq(expected)
     end
@@ -83,6 +85,7 @@ RSpec.describe HoneyFormat::CLI do
         "--csv=input.csv",
         "--columns=id,name",
         "--output=output.csv",
+        "--skip-lines=buren",
         "--delimiter=:",
         "--header-only",
         "--no-rows-only"
@@ -94,7 +97,8 @@ RSpec.describe HoneyFormat::CLI do
         output_path: "output.csv",
         delimiter: ":",
         header_only: true,
-        rows_only: false
+        rows_only: false,
+        skip_lines: "buren"
       }
       expect(cli.options).to eq(expected)
     end

--- a/spec/honey_format/csv_spec.rb
+++ b/spec/honey_format/csv_spec.rb
@@ -64,6 +64,32 @@ let(:diabolical_cols) {
     end
   end
 
+  describe 'with comment lines' do
+    it 'can skip lines that match given regexp' do
+      comment_regexp = %r{\A#|\/\/} # consider "#" and "//" comments
+      csv_string = <<~CSV
+      id,username
+      1,buren
+      # this is a comment
+      // this is also comment
+      2,jacob
+      CSV
+      csv = HoneyFormat::CSV.new(csv_string, skip_lines: comment_regexp)
+      expect(csv.rows.length).to eq(2)
+    end
+
+    it 'can skip lines that match a given string' do
+      csv_string = <<~CSV
+      id,username
+      1,buren
+      # this is a comment
+      2,jacob
+      CSV
+      csv = HoneyFormat::CSV.new(csv_string, skip_lines: '#')
+      expect(csv.rows.length).to eq(2)
+    end
+  end
+
   describe '#each_row' do
     it 'yields each row' do
       csv = described_class.new("email, ids\ntest@example.com,42")


### PR DESCRIPTION
__Example__

```ruby
csv_string = <<~CSV
Id,Username
1,buren
# comment
2,jacob
CSV
regexp = %r{\A#} # Match all lines that start with "#"
csv = HoneyFormat::CSV.new(csv_string, skip_lines: regexp)
csv.rows.length # => 2
```

Closes #17