### PR TITLE
Add --type-map option to CLI

### DIFF
--- a/exe/honey_format
+++ b/exe/honey_format
@@ -14,6 +14,7 @@ csv_input = File.read(input_path)
 csv = HoneyFormat::CSV.new(
   csv_input,
   delimiter: options[:delimiter],
+  type_map: options[:type_map],
   skip_lines: options[:skip_lines]
 )
 

--- a/lib/honey_format/cli/cli.rb
+++ b/lib/honey_format/cli/cli.rb
@@ -30,6 +30,7 @@ module HoneyFormat
       header_only = false
       rows_only = false
       skip_lines = nil
+      type_map = {}
 
       OptionParser.new do |parser|
         parser.banner = "Usage: honey_format [options] <file.csv>"
@@ -53,6 +54,10 @@ module HoneyFormat
 
         parser.on("--skip-lines=,", String, "Skip lines that match this pattern") do |value|
           skip_lines = value
+        end
+
+        parser.on('--type-map=[key1=val1,key2=val2]', Array, 'Type map') do |value|
+          type_map = option_to_h(value || [])
         end
 
         parser.on("--[no-]header-only", "Print only the header") do |value|
@@ -90,8 +95,13 @@ module HoneyFormat
         delimiter: delimiter,
         header_only: header_only,
         rows_only: rows_only,
-        skip_lines: skip_lines
+        skip_lines: skip_lines,
+        type_map: type_map
       }
+    end
+
+    def option_to_h(option)
+      option.map { |v| v.split('=').map(&:to_sym) }.to_h
     end
   end
 end

--- a/spec/honey_format/cli/cli_spec.rb
+++ b/spec/honey_format/cli/cli_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe HoneyFormat::CLI do
         delimiter: ",",
         header_only: false,
         rows_only: false,
+        type_map: {},
         skip_lines: nil
       }
       expect(cli.options).to eq(expected)
@@ -75,6 +76,7 @@ RSpec.describe HoneyFormat::CLI do
         delimiter: ",",
         header_only: false,
         rows_only: false,
+        type_map: {},
         skip_lines: nil
       }
       expect(cli.options).to eq(expected)
@@ -88,7 +90,8 @@ RSpec.describe HoneyFormat::CLI do
         "--skip-lines=buren",
         "--delimiter=:",
         "--header-only",
-        "--no-rows-only"
+        "--no-rows-only",
+        "--type-map=id=integer,name=upcase"
       ]
       cli = described_class.new(argv: argv)
       expected = {
@@ -98,6 +101,7 @@ RSpec.describe HoneyFormat::CLI do
         delimiter: ":",
         header_only: true,
         rows_only: false,
+        type_map: { id: :integer, name: :upcase },
         skip_lines: "buren"
       }
       expect(cli.options).to eq(expected)


### PR DESCRIPTION
`file.csv`:
```
Id,Username
1,buren
2,jacob
```

Pass type map to CLI

```
$ exe/honey_format --type-map=username=upcase file.csv
id,username
1,BUREN
2,JACOB
```

Closes #23 
