### PR TITLE
Allow unregister of existing value converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ csv = HoneyFormat::CSV.new(csv_string, type_map: type_map)
 csv.rows.first.username # => "BUREN"
 ```
 
+Remove registered converter
+```ruby
+HoneyFormat.configure do |config|
+  config.converter.unregister :upcase
+  # now you're free to register your own
+  config.converter.register :upcase, proc { |v| v.upcase if v }
+end
+```
+
 Access registered converters
 ```ruby
 decimal_converter = HoneyFormat.value_converter[:decimal]

--- a/lib/honey_format/value_converter.rb
+++ b/lib/honey_format/value_converter.rb
@@ -79,6 +79,16 @@ module HoneyFormat
       self
     end
 
+    # Unregister a value converter
+    # @param [Symbol, String] type the name of the type
+    # @return [ValueConverter] returns self
+    # @raise [UnknownValueTypeError] if type is already registered
+    def unregister(type)
+      unknown_type_error!(type) unless type?(type)
+      @converters.delete(to_key(type))
+      self
+    end
+
     # Convert value
     # @param [Symbol, String] type the name of the type
     # @param [Object] value to be converted
@@ -92,7 +102,7 @@ module HoneyFormat
     # @return [Object] returns the converter
     # @raise [ValueTypeExistsError] if type is already registered
     def []=(type, converter)
-      type = type.to_sym
+      type = to_key(type)
 
       if type?(type)
         raise(Errors::ValueTypeExistsError, "type '#{type}' already exists")
@@ -105,15 +115,23 @@ module HoneyFormat
     # @return [Object] returns the converter
     # @raise [UnknownValueTypeError] if type does not exist
     def [](type)
-      @converters.fetch(type.to_sym) do
-        raise(Errors::UnknownValueTypeError, "unknown type '#{type}'")
-      end
+      @converters.fetch(to_key(type)) { unknown_type_error!(type) }
     end
 
     # @param [Symbol, String] type the name of the type
     # @return [true, false] true if type exists, false otherwise
     def type?(type)
-      @converters.key?(type.to_sym)
+      @converters.key?(to_key(type))
+    end
+
+    private
+
+    def to_key(key)
+      key.to_sym
+    end
+
+    def unknown_type_error!(type)
+      raise(Errors::UnknownValueTypeError, "unknown type '#{type}'")
     end
   end
 end

--- a/spec/honey_format/value_converter_spec.rb
+++ b/spec/honey_format/value_converter_spec.rb
@@ -3,7 +3,33 @@ require 'spec_helper'
 require 'honey_format/value_converter'
 
 RSpec.describe HoneyFormat::ValueConverter do
+  describe "#unregister" do
+    it 'can unregister known type' do
+      value_converter = described_class.new
+      value_converter.register(:watman, proc {})
+      value_converter.unregister(:watman)
+
+      expect(value_converter.type?(:watman)).to eq(false)
+    end
+
+    it 'raises Errors::UnknownValueTypeError when trying to unregister unknown type' do
+      value_converter = described_class.new
+      expect do
+        value_converter.unregister(:watman)
+      end.to raise_error(HoneyFormat::Errors::UnknownValueTypeError)
+    end
+  end
+
   describe "#register" do
+    it 'can register type' do
+      value_converter = described_class.new
+      value_converter.register(:watman, proc {})
+      expect(value_converter.type?(:watman)).to eq(true)
+
+      # we must unregister the type since its global configuration
+      value_converter.unregister(:watman)
+    end
+
     it 'raises Errors::ValueTypeExistsError when trying to register duplicated type' do
       value_converter = described_class.new
       expect do


### PR DESCRIPTION
Remove registered converter
```ruby
HoneyFormat.configure do |config|
  config.converter.unregister :upcase
  # now you're free to register your own
  config.converter.register :upcase, proc { |v| v.upcase if v }
end
```