### PR TITLE
Header deduplication strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,23 @@ user = csv.rows.first
 user.column1 # => "val1"
 ```
 
+Duplicated header values
+```ruby
+csv_string = <<~CSV
+  email,email,name
+  john@example.com,jane@example.com,John
+CSV
+# :deduplicate is the default value
+csv = HoneyFormat::CSV.new(csv_string, header_deduplicator: :deduplicate)
+user = csv.rows.first
+user.email  # => john@example.com
+user.email1 # => jane@example.com
+
+# you can also choose to raise an error instead
+HoneyFormat::CSV.new(csv_string, header_deduplicator: :raise)
+# => HoneyFormat::DuplicateHeaderColumnError
+```
+
 If your header contains special chars and/or chars that can't be part of Ruby method names,
 things can get a little awkward..
 ```ruby

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ csv.rows.first.id # => 1
 Add your own converter
 ```ruby
 HoneyFormat.configure do |config|
-  config.converter.register :upcased, proc { |v| v.upcase }
+  config.converter_registry.register :upcased, proc { |v| v.upcase }
 end
 
 csv_string = "Id,Username\n1,buren"
@@ -114,15 +114,15 @@ csv.rows.first.username # => "BUREN"
 Remove registered converter
 ```ruby
 HoneyFormat.configure do |config|
-  config.converter.unregister :upcase
+  config.converter_registry.unregister :upcase
   # now you're free to register your own
-  config.converter.register :upcase, proc { |v| v.upcase if v }
+  config.converter_registry.register :upcase, proc { |v| v.upcase if v }
 end
 ```
 
 Access registered converters
 ```ruby
-decimal_converter = HoneyFormat.converter[:decimal]
+decimal_converter = HoneyFormat.converter_registry[:decimal]
 decimal_converter.call('1.1') # => 1.1
 ```
 
@@ -222,7 +222,7 @@ HoneyFormat.configure do |config|
 end
 
 # you can get the default one with
-header_converter = HoneyFormat.converter[:header_column]
+header_converter = HoneyFormat.converter_registry[:header_column]
 header_converter.call('First name') # => "first_name"
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Proper objects for CSV headers and rows, convert column values, filter columns a
 ## Features
 
 - Proper objects for CSV header and rows
-- Convert column values
+- Convert row and header column values
 - Pass your own custom row builder
-- Convert header column names
 - Filter what columns and rows are included in CSV output
+- Gracefully handle missing and duplicated header columns
 - [CLI](#cli) - Simple command line interface
 - Only ~5-10% overhead from using Ruby CSV, see [benchmarks](#benchmark)
 - Has no dependencies other than Ruby stdlib
@@ -19,7 +19,6 @@ Proper objects for CSV headers and rows, convert column values, filter columns a
 Read the [usage section](#usage),  [RubyDoc](https://www.rubydoc.info/gems/honey_format/) or [examples/ directory](https://github.com/buren/honey_format/tree/master/examples)  for how to use this gem.
 
 ## Quick use
-
 
 ```ruby
 csv_string = <<-CSV

--- a/examples/complete_example.rb
+++ b/examples/complete_example.rb
@@ -13,8 +13,8 @@ csv_string = <<~CSV
 CSV
 
 HoneyFormat.configure do |config|
-  config.converter.register(:upcased, proc { |v| v.upcase })
-  config.converter.register(:country, proc { |v| v == 'SE' ? 'SWEDEN' : v })
+  config.converter_registry.register(:upcased, proc { |v| v.upcase })
+  config.converter_registry.register(:country, proc { |v| v == 'SE' ? 'SWEDEN' : v })
 end
 
 puts '== EXAMPLE: CSV complete example =='

--- a/examples/convert_values.rb
+++ b/examples/convert_values.rb
@@ -9,8 +9,8 @@ csv_string = <<~CSV
 CSV
 
 HoneyFormat.configure do |config|
-  config.converter.register(:upcased, proc { |v| v.upcase })
-  config.converter.register(:country, proc { |v| v == 'SE' ? 'SWEDEN' : v })
+  config.converter_registry.register(:upcased, proc { |v| v.upcase })
+  config.converter_registry.register(:country, proc { |v| v == 'SE' ? 'SWEDEN' : v })
 end
 
 type_map = {

--- a/examples/header_deduplication.rb
+++ b/examples/header_deduplication.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'honey_format'
+
+csv_string = <<~CSV
+  email,email,name
+  john@example.com,jane@example.com,John
+CSV
+
+puts '== EXAMPLE: CSV with duplicated header columns =='
+puts
+puts '== CSV START =='
+csv = HoneyFormat::CSV.new(csv_string, header_deduplicator: :deduplicate)
+puts csv.to_csv
+puts '== CSV END =='

--- a/examples/import_users.rb
+++ b/examples/import_users.rb
@@ -29,7 +29,7 @@ end
 
 HoneyFormat.configure do |config|
   # Register the country coder
-  config.converter.register :country_code, country_coder
+  config.converter_registry.register :country_code, country_coder
 end
 
 # Convert the country header column to country_code

--- a/examples/type_map.rb
+++ b/examples/type_map.rb
@@ -24,11 +24,11 @@ country_code_converter = proc { |v|
 puts '== EXAMPLE: CSV output with filtered columns and rows =='
 puts
 puts 'The type converters available by default are:'
-puts "    #{HoneyFormat.converter.types.join(', ')}"
+puts "    #{HoneyFormat.converter_registry.types.join(', ')}"
 puts
 
 HoneyFormat.configure do |config|
-  config.converter.register(:country_code, country_code_converter)
+  config.converter_registry.register(:country_code, country_code_converter)
 end
 
 # Map columns to types

--- a/lib/honey_format.rb
+++ b/lib/honey_format.rb
@@ -42,7 +42,7 @@ module HoneyFormat
 
   # Returns the configured deduplicator registry
   # @return [Registry] the current deduplicator registry
-  def self.header_deduplicator
-    config.header_deduplicator
+  def self.header_deduplicator_registry
+    config.header_deduplicator_registry
   end
 end

--- a/lib/honey_format.rb
+++ b/lib/honey_format.rb
@@ -3,8 +3,8 @@
 require 'honey_format/version'
 require 'honey_format/configuration'
 require 'honey_format/errors'
+require 'honey_format/registry'
 require 'honey_format/converters/converters'
-require 'honey_format/converters/converter_registry'
 require 'honey_format/csv'
 
 # Main module for HoneyFormat

--- a/lib/honey_format.rb
+++ b/lib/honey_format.rb
@@ -35,13 +35,13 @@ module HoneyFormat
   end
 
   # Returns the configured converter registry
-  # @return [#call] the current converter registry
+  # @return [Registry] the current converter registry
   def self.converter
     config.converter
   end
 
   # Returns the configured deduplicator registry
-  # @return [#call] the current deduplicator registry
+  # @return [Registry] the current deduplicator registry
   def self.header_deduplicator
     config.header_deduplicator
   end

--- a/lib/honey_format.rb
+++ b/lib/honey_format.rb
@@ -39,4 +39,10 @@ module HoneyFormat
   def self.converter
     config.converter
   end
+
+  # Returns the configured deduplicator registry
+  # @return [#call] the current deduplicator registry
+  def self.header_deduplicator
+    config.header_deduplicator
+  end
 end

--- a/lib/honey_format.rb
+++ b/lib/honey_format.rb
@@ -36,8 +36,8 @@ module HoneyFormat
 
   # Returns the configured converter registry
   # @return [Registry] the current converter registry
-  def self.converter
-    config.converter
+  def self.converter_registry
+    config.converter_registry
   end
 
   # Returns the configured deduplicator registry

--- a/lib/honey_format/configuration.rb
+++ b/lib/honey_format/configuration.rb
@@ -76,7 +76,7 @@ module HoneyFormat
     # Returns the converter registry
     # @return [#call] converter the configured converter registry
     def converter
-      @converter ||= ConverterRegistry.new
+      @converter ||= ConverterRegistry.new(default_converters)
     end
 
     # Default converter registry

--- a/lib/honey_format/configuration.rb
+++ b/lib/honey_format/configuration.rb
@@ -55,8 +55,8 @@ module HoneyFormat
 
     # Default header deduplicate strategies
     # @return [Hash] the default header deduplicatation strategies
-    def default_header_deduplicator_strategies
-      @default_header_deduplicator_strategies ||= {
+    def default_header_deduplicators
+      @default_header_deduplicators ||= {
         deduplicate: proc do |columns|
           Helpers.key_count_to_deduplicated_array(columns)
         end,
@@ -75,7 +75,7 @@ module HoneyFormat
     # Returns the column deduplication registry
     # @return [#call] column deduplication registry
     def header_deduplicator_registry
-      @header_deduplicator_registry ||= Registry.new(default_header_deduplicator_strategies)
+      @header_deduplicator_registry ||= Registry.new(default_header_deduplicators)
     end
 
     # Returns the converter registry

--- a/lib/honey_format/configuration.rb
+++ b/lib/honey_format/configuration.rb
@@ -33,7 +33,7 @@ module HoneyFormat
     # Return the deduplication header strategy
     # @return [#call] the header deduplication strategy
     def deduplicate_header
-      @deduplicate_header ||= header_deduplicator[:deduplicate]
+      @deduplicate_header ||= header_deduplicator_registry[:deduplicate]
     end
 
     # Set the deduplication header strategy
@@ -43,8 +43,8 @@ module HoneyFormat
     # @return [#call] the header deduplication strategy
     # @raise [UnknownDeduplicationStrategyError]
     def deduplicate_header=(strategy)
-      if header_deduplicator.type?(strategy)
-        @deduplicate_header = header_deduplicator[strategy]
+      if header_deduplicator_registry.type?(strategy)
+        @deduplicate_header = header_deduplicator_registry[strategy]
       elsif strategy.respond_to?(:call)
         @deduplicate_header = strategy
       else
@@ -74,8 +74,8 @@ module HoneyFormat
 
     # Returns the column deduplication registry
     # @return [#call] column deduplication registry
-    def header_deduplicator
-      @header_deduplicator ||= Registry.new(default_deduplicate_header_strategies)
+    def header_deduplicator_registry
+      @header_deduplicator_registry ||= Registry.new(default_deduplicate_header_strategies)
     end
 
     # Returns the converter registry

--- a/lib/honey_format/configuration.rb
+++ b/lib/honey_format/configuration.rb
@@ -76,7 +76,7 @@ module HoneyFormat
     # Returns the converter registry
     # @return [#call] converter the configured converter registry
     def converter
-      @converter ||= ConverterRegistry.new(default_converters)
+      @converter ||= Registry.new(default_converters)
     end
 
     # Default converter registry

--- a/lib/honey_format/configuration.rb
+++ b/lib/honey_format/configuration.rb
@@ -74,7 +74,7 @@ module HoneyFormat
     end
 
     # Returns the converter registry
-    # @attr_reader [#call] converter the configured converter registry
+    # @return [#call] converter the configured converter registry
     def converter
       @converter ||= ConverterRegistry.new
     end

--- a/lib/honey_format/converters/converter_registry.rb
+++ b/lib/honey_format/converters/converter_registry.rb
@@ -1,83 +1,83 @@
 # frozen_string_literal: true
 
 module HoneyFormat
-  # Convert registry that holds value converters
+  # Registry that holds value callers
   class ConverterRegistry
-    # Instantiate a converter registry
-    # @param [Hash] default_converters hash of default converters
-    def initialize(default_converters = HoneyFormat.config.default_converters)
-      @converters = nil
-      @default = default_converters.dup
+    # Instantiate a caller registry
+    # @param [Hash] default hash of defaults
+    def initialize(default = {})
+      @callers = nil
+      @default = default.dup
       reset!
     end
 
     # Returns list of registered types
     # @return [Array<Symbol>] list of registered types
     def types
-      @converters.keys
+      @callers.keys
     end
 
-    # Register a converter
+    # Register a caller
     # @param [Symbol, String] type the name of the type
-    # @param [#call] converter that responds to #call
-    # @return [ConverterRegistry] returns self
-    # @raise [ValueTypeExistsError] if type is already registered
-    def register(type, converter)
-      self[type] = converter
+    # @param [#call] caller that responds to #call
+    # @return [Registry] returns self
+    # @raise [TypeExistsError] if type is already registered
+    def register(type, caller)
+      self[type] = caller
       self
     end
 
-    # Unregister a converter
+    # Unregister a caller
     # @param [Symbol, String] type the name of the type
-    # @return [ConverterRegistry] returns self
+    # @return [Registry] returns self
     # @raise [UnknownTypeError] if type is already registered
     def unregister(type)
       unknown_type_error!(type) unless type?(type)
-      @converters.delete(to_key(type))
+      @callers.delete(to_key(type))
       self
     end
 
-    # Convert value
+    # Call value type
     # @param [Symbol, String] type the name of the type
     # @param [Object] value to be converted
     def call(value, type)
       self[type].call(value)
     end
 
-    # Register a converter
+    # Register a caller
     # @param [Symbol, String] type the name of the type
-    # @param [#call] converter that responds to #call
-    # @return [Object] returns the converter
-    # @raise [ValueTypeExistsError] if type is already registered
-    def []=(type, converter)
+    # @param [#call] caller that responds to #call
+    # @return [Object] returns the caller
+    # @raise [TypeExistsError] if type is already registered
+    def []=(type, caller)
       type = to_key(type)
 
       if type?(type)
-        raise(Errors::ValueTypeExistsError, "type '#{type}' already exists")
+        raise(Errors::TypeExistsError, "type '#{type}' already exists")
       end
 
-      @converters[type] = converter
+      @callers[type] = caller
     end
 
     # Returns the given type or raises error if type doesn't exist
     # @param [Symbol, String] type the name of the type
-    # @return [Object] returns the converter
+    # @return [Object] returns the caller
     # @raise [UnknownTypeError] if type does not exist
     def [](type)
-      @converters.fetch(to_key(type)) { unknown_type_error!(type) }
+      @callers.fetch(to_key(type)) { unknown_type_error!(type) }
     end
 
     # Returns true if the type exists, false otherwise
     # @param [Symbol, String] type the name of the type
     # @return [true, false] true if type exists, false otherwise
     def type?(type)
-      @converters.key?(to_key(type))
+      @callers.key?(to_key(type))
     end
 
-    # Resets the converter registry to its default configuration
-    # @return [ConverterRegistry] returns the converter registry
+    # Resets the caller registry to its default configuration
+    # @return [Registry] returns the caller registry
     def reset!
-      @converters = @default.dup
+      @callers = @default.dup
       self
     end
 

--- a/lib/honey_format/csv.rb
+++ b/lib/honey_format/csv.rb
@@ -51,7 +51,7 @@ module HoneyFormat
       quote_character: '"',
       header: nil,
       header_converter: HoneyFormat.header_converter,
-      header_deduplicator: HoneyFormat.config.deduplicate_header,
+      header_deduplicator: HoneyFormat.config.header_deduplicator,
       row_builder: nil,
       type_map: {},
       skip_lines: nil

--- a/lib/honey_format/csv.rb
+++ b/lib/honey_format/csv.rb
@@ -9,14 +9,15 @@ module HoneyFormat
     # Instantiate CSV.
     # @return [CSV] a new instance of CSV.
     # @param [String] csv the CSV string
-    # @param [String] delimiter the CSV column delimiter
-    # @param [String, Symbol] row_delimiter the CSV row delimiter (default: :auto)
-    # @param [String] quote_character the CSV quote character (default: ")
-    # @param [Array<String>]
+    # @param delimiter [String] the CSV column delimiter
+    # @param row_delimiter [String, Symbol] the CSV row delimiter (default: :auto)
+    # @param quote_character [String] the CSV quote character (default: ")
+    # @param header [Array<String>]
     #   header optional argument that represents CSV header, required if the CSV file
     #   lacks a header row.
-    # @param [#call] header_converter converts header columns.
-    # @param [#call] row_builder will be called for each parsed row.
+    # @param header_converter [#call] converts header columns.
+    # @param header_deduplicator [#call] deduplicates header columns.
+    # @param row_builder [#call] will be called for each parsed row.
     # @param type_map [Hash] map of column_name => type conversion to perform.
     # @param skip_lines [Regexp, String]
     #   Regexp for determining wheter a line is a comment. See CSV skip_lines option.
@@ -50,6 +51,7 @@ module HoneyFormat
       quote_character: '"',
       header: nil,
       header_converter: HoneyFormat.header_converter,
+      header_deduplicator: HoneyFormat.config.deduplicate_header,
       row_builder: nil,
       type_map: {},
       skip_lines: nil
@@ -66,6 +68,7 @@ module HoneyFormat
         csv,
         header: header,
         header_converter: header_converter,
+        header_deduplicator: header_deduplicator,
         row_builder: row_builder,
         type_map: type_map
       )

--- a/lib/honey_format/errors.rb
+++ b/lib/honey_format/errors.rb
@@ -10,6 +10,8 @@ module HoneyFormat
     class MissingHeaderError < HeaderError; end
     # Raised when header column is missing
     class MissingHeaderColumnError < HeaderError; end
+    # Raised when header column duplicate is found
+    class DuplicateHeaderColumnError < HeaderError; end
 
     # Row errors
     # Super class of errors raised when there is a row error

--- a/lib/honey_format/errors.rb
+++ b/lib/honey_format/errors.rb
@@ -12,6 +12,8 @@ module HoneyFormat
     class MissingHeaderColumnError < HeaderError; end
     # Raised when header column duplicate is found
     class DuplicateHeaderColumnError < HeaderError; end
+    # Raised when deduplication strategy is unknown
+    class UnknownDeduplicationStrategyError < HeaderError; end
 
     # Row errors
     # Super class of errors raised when there is a row error

--- a/lib/honey_format/errors.rb
+++ b/lib/honey_format/errors.rb
@@ -25,7 +25,7 @@ module HoneyFormat
     # Raised when value type is unknown
     class UnknownTypeError < ArgumentError; end
     # Raised when value type already exists
-    class ValueTypeExistsError < ArgumentError; end
+    class TypeExistsError < ArgumentError; end
   end
 
   include Errors

--- a/lib/honey_format/helpers/helpers.rb
+++ b/lib/honey_format/helpers/helpers.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module HoneyFormat
+  module Helpers
+    # Converts a Hash with key => count to a deduplicated array.
+    # @param [Hash] data with key => count
+    # @return [Array<Symbol>] an array of symbols
+    # @example
+    #   Helpers.key_count_to_deduplicated_array({ a: 2, b: 1, c: 0})
+    #   # => [:a, :a1, :b]
+    def self.key_count_to_deduplicated_array(data)
+      array = []
+      count_occurences(data).each do |key, value|
+        next array << key if value == 1
+
+        values = Array.new(value) { |i| i }.map do |index|
+          next key if index.zero?
+          :"#{key}#{index}"
+        end
+        array.concat(values)
+      end
+      array
+    end
+
+    # Returns hash with key => occurrences_count
+    # @param [Array<Object>] the array to count occurrences in
+    # @return [Hash] key => occurrences_count
+    def self.count_occurences(array)
+      occurrences = Hash.new(0)
+      array.each { |column| occurrences[column] += 1 }
+      occurrences
+    end
+
+    # Returns array with duplicated objects
+    # @param [Array<Object>] the array to find duplicates in
+    # @return [Array<Object>] array of duplicated objects
+    def self.duplicated_items(array)
+      array.select { |col| array.count(col) > 1 }.uniq
+    end
+  end
+end

--- a/lib/honey_format/matrix/header.rb
+++ b/lib/honey_format/matrix/header.rb
@@ -27,7 +27,7 @@ module HoneyFormat
     def initialize(
       header,
       converter: HoneyFormat.header_converter,
-      deduplicator: HoneyFormat.config.deduplicate_header
+      deduplicator: HoneyFormat.config.header_deduplicator
     )
       if header.nil? || header.empty?
         raise(Errors::MissingHeaderError, "CSV header can't be empty.")
@@ -97,7 +97,7 @@ module HoneyFormat
     # @return [nil]
     def converter=(object)
       if object.is_a?(Symbol)
-        @converter = HoneyFormat.converter[object]
+        @converter = HoneyFormat.converter_registry[object]
         return
       end
 

--- a/lib/honey_format/matrix/header.rb
+++ b/lib/honey_format/matrix/header.rb
@@ -14,6 +14,10 @@ module HoneyFormat
     #   header converter that implements a #call method
     #   that takes one column (string) argument OR symbol for a registered
     #   converter registry.
+    # @param deduplicator [#call, Symbol]
+    #   header deduplicator that implements a #call method
+    #   that takes columns Array<String> argument OR symbol for a registered
+    #   deduplicator registry.
     # @raise [HeaderError] super class of errors raised when there is a CSV header error.
     # @raise [MissingHeaderColumnError] raised when header is missing
     # @example Instantiate a header with a custom converter

--- a/lib/honey_format/matrix/header.rb
+++ b/lib/honey_format/matrix/header.rb
@@ -109,7 +109,7 @@ module HoneyFormat
     # @return [nil]
     def deduplicator=(object)
       if object.is_a?(Symbol)
-        @deduplicator = HoneyFormat.header_deduplicator[object]
+        @deduplicator = HoneyFormat.header_deduplicator_registry[object]
         return
       end
 

--- a/lib/honey_format/matrix/matrix.rb
+++ b/lib/honey_format/matrix/matrix.rb
@@ -41,7 +41,7 @@ module HoneyFormat
       matrix,
       header: nil,
       header_converter: HoneyFormat.header_converter,
-      header_deduplicator: HoneyFormat.config.deduplicate_header,
+      header_deduplicator: HoneyFormat.config.header_deduplicator,
       row_builder: nil,
       type_map: {}
     )

--- a/lib/honey_format/matrix/matrix.rb
+++ b/lib/honey_format/matrix/matrix.rb
@@ -6,11 +6,12 @@ module HoneyFormat
     # Instantiate Matrix.
     # @return [Matrix] a new instance of Matrix.
     # @param [Array<Array<String, nil>>] matrix
-    # @param [Array<String>]
+    # @param header [Array<String>]
     #   header optional argument that represents header, required if the matrix
     #   lacks a header row.
-    # @param [#call] header_converter converts header columns.
-    # @param [#call] row_builder will be called for each parsed row.
+    # @param header_converter [#call] converts header columns.
+    # @param header_deduplicator [#call] deduplicates header columns.
+    # @param row_builder [#call] will be called for each parsed row.
     # @param type_map [Hash] map of column_name => type conversion to perform.
     # @raise [HeaderError] super class of errors raised when there is a header error.
     # @raise [MissingHeaderError] raised when header is missing (empty or nil).
@@ -34,15 +35,22 @@ module HoneyFormat
     #   rescue HoneyFormat::RowError => e
     #     puts "row error: #{e.class}, #{e.message}"
     #   end
+    # @see Header#initialize
+    # @see Rows#initialize
     def initialize(
       matrix,
       header: nil,
       header_converter: HoneyFormat.header_converter,
+      header_deduplicator: HoneyFormat.config.deduplicate_header,
       row_builder: nil,
       type_map: {}
     )
       header_row = header || matrix.shift
-      @header = Header.new(header_row, converter: header_converter)
+      @header = Header.new(
+        header_row,
+        converter: header_converter,
+        deduplicator: header_deduplicator
+      )
       @rows = Rows.new(matrix, columns, builder: row_builder, type_map: type_map)
     end
 

--- a/lib/honey_format/matrix/row_builder.rb
+++ b/lib/honey_format/matrix/row_builder.rb
@@ -20,7 +20,7 @@ module HoneyFormat
       end
 
       @type_map = type_map
-      @converter = HoneyFormat.converter
+      @converter = HoneyFormat.converter_registry
 
       @row_klass = Row.new(*columns)
       @builder = builder

--- a/lib/honey_format/registry.rb
+++ b/lib/honey_format/registry.rb
@@ -71,6 +71,7 @@ module HoneyFormat
     # @param [Symbol, String] type the name of the type
     # @return [true, false] true if type exists, false otherwise
     def type?(type)
+      return false unless keyable?(type)
       @callers.key?(to_key(type))
     end
 
@@ -82,6 +83,10 @@ module HoneyFormat
     end
 
     private
+
+    def keyable?(key)
+      key.respond_to?(:to_sym)
+    end
 
     def to_key(key)
       key.to_sym

--- a/lib/honey_format/registry.rb
+++ b/lib/honey_format/registry.rb
@@ -2,7 +2,7 @@
 
 module HoneyFormat
   # Registry that holds value callers
-  class ConverterRegistry
+  class Registry
     # Instantiate a caller registry
     # @param [Hash] default hash of defaults
     def initialize(default = {})

--- a/spec/honey_format/configuration_spec.rb
+++ b/spec/honey_format/configuration_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe HoneyFormat::Configuration do
   describe '#header_converter=' do
     it 'can set header converter from Symbol' do
-      expected = HoneyFormat.converter[:upcase]
+      expected = HoneyFormat.converter_registry[:upcase]
 
       config = described_class.new
       config.header_converter = :upcase
@@ -14,7 +14,7 @@ RSpec.describe HoneyFormat::Configuration do
     end
 
     it 'can set header converter' do
-      expected = HoneyFormat.converter[:upcase]
+      expected = HoneyFormat.converter_registry[:upcase]
 
       config = described_class.new
       config.header_converter = expected
@@ -25,24 +25,24 @@ RSpec.describe HoneyFormat::Configuration do
 
   describe '#converter' do
     it 'returns a converter registry' do
-      expect(described_class.new.converter).to be_a(HoneyFormat::Registry)
+      expect(described_class.new.converter_registry).to be_a(HoneyFormat::Registry)
     end
   end
 
-  describe '#deduplicate_header=' do
+  describe '#header_deduplicator=' do
     it 'can set header converter from Symbol' do
       config = described_class.new
-      config.deduplicate_header = :none
-      expected = config.default_deduplicate_header_strategies[:none]
+      config.header_deduplicator = :none
+      expected = config.default_header_deduplicator_strategies[:none]
 
-      expect(config.deduplicate_header).to eq(expected)
+      expect(config.header_deduplicator).to eq(expected)
     end
 
     it 'raises error for unknown Symbol deduplicator' do
       config = described_class.new
 
       expect do
-        config.deduplicate_header = :invalid_thing
+        config.header_deduplicator = :invalid_thing
       end.to raise_error(HoneyFormat::Errors::UnknownDeduplicationStrategyError)
     end
 
@@ -50,7 +50,7 @@ RSpec.describe HoneyFormat::Configuration do
       config = described_class.new
 
       expect do
-        config.deduplicate_header = 'wat'
+        config.header_deduplicator = 'wat'
       end.to raise_error(HoneyFormat::Errors::UnknownDeduplicationStrategyError)
     end
 
@@ -58,9 +58,9 @@ RSpec.describe HoneyFormat::Configuration do
       expected = proc { |v| v }
 
       config = described_class.new
-      config.deduplicate_header = expected
+      config.header_deduplicator = expected
 
-      expect(config.deduplicate_header).to eq(expected)
+      expect(config.header_deduplicator).to eq(expected)
     end
   end
 end

--- a/spec/honey_format/configuration_spec.rb
+++ b/spec/honey_format/configuration_spec.rb
@@ -28,4 +28,22 @@ RSpec.describe HoneyFormat::Configuration do
       expect(described_class.new.converter).to be_a(HoneyFormat::ConverterRegistry)
     end
   end
+
+  describe '#deduplicate_header_strategy=' do
+    it 'can set header converter from Symbol' do
+      config = described_class.new
+      config.deduplicate_header_strategy = :deduplicate
+
+      expect(config.deduplicate_header_strategy).to be_a(Proc)
+    end
+
+    it 'can set header converter' do
+      expected = proc { |v| v }
+
+      config = described_class.new
+      config.deduplicate_header_strategy = expected
+
+      expect(config.deduplicate_header_strategy).to eq(expected)
+    end
+  end
 end

--- a/spec/honey_format/configuration_spec.rb
+++ b/spec/honey_format/configuration_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe HoneyFormat::Configuration do
 
   describe '#converter' do
     it 'returns a converter registry' do
-      expect(described_class.new.converter).to be_a(HoneyFormat::ConverterRegistry)
+      expect(described_class.new.converter).to be_a(HoneyFormat::Registry)
     end
   end
 

--- a/spec/honey_format/configuration_spec.rb
+++ b/spec/honey_format/configuration_spec.rb
@@ -29,21 +29,38 @@ RSpec.describe HoneyFormat::Configuration do
     end
   end
 
-  describe '#deduplicate_header_strategy=' do
+  describe '#deduplicate_header=' do
     it 'can set header converter from Symbol' do
       config = described_class.new
-      config.deduplicate_header_strategy = :deduplicate
+      config.deduplicate_header = :none
+      expected = config.default_deduplicate_header_strategies[:none]
 
-      expect(config.deduplicate_header_strategy).to be_a(Proc)
+      expect(config.deduplicate_header).to eq(expected)
+    end
+
+    it 'raises error for unknown Symbol deduplicator' do
+      config = described_class.new
+
+      expect do
+        config.deduplicate_header = :invalid_thing
+      end.to raise_error(HoneyFormat::Errors::UnknownDeduplicationStrategyError)
+    end
+
+    it 'raises error in invalid deduplicator' do
+      config = described_class.new
+
+      expect do
+        config.deduplicate_header = 'wat'
+      end.to raise_error(HoneyFormat::Errors::UnknownDeduplicationStrategyError)
     end
 
     it 'can set header converter' do
       expected = proc { |v| v }
 
       config = described_class.new
-      config.deduplicate_header_strategy = expected
+      config.deduplicate_header = expected
 
-      expect(config.deduplicate_header_strategy).to eq(expected)
+      expect(config.deduplicate_header).to eq(expected)
     end
   end
 end

--- a/spec/honey_format/configuration_spec.rb
+++ b/spec/honey_format/configuration_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe HoneyFormat::Configuration do
     it 'can set header converter from Symbol' do
       config = described_class.new
       config.header_deduplicator = :none
-      expected = config.default_header_deduplicator_strategies[:none]
+      expected = config.default_header_deduplicators[:none]
 
       expect(config.header_deduplicator).to eq(expected)
     end

--- a/spec/honey_format/converters/converter_registry_spec.rb
+++ b/spec/honey_format/converters/converter_registry_spec.rb
@@ -44,11 +44,11 @@ RSpec.describe HoneyFormat::ConverterRegistry do
       converter_registry.reset!
     end
 
-    it 'raises ValueTypeExistsError when trying to register duplicated type' do
+    it 'raises TypeExistsError when trying to register duplicated type' do
       converter_registry = described_class.new(default_converters)
       expect do
         converter_registry.register(:datetime!, proc {})
-      end.to raise_error(HoneyFormat::ValueTypeExistsError)
+      end.to raise_error(HoneyFormat::TypeExistsError)
     end
   end
 

--- a/spec/honey_format/converters/converters_spec.rb
+++ b/spec/honey_format/converters/converters_spec.rb
@@ -14,16 +14,16 @@ RSpec.describe HoneyFormat::Registry do
   end
 
   it 'can convert custom value' do
-    converter_registry = described_class.new(default_converters)
-    converter_registry.register(:upcased, proc { |v| v.upcase })
-    value = converter_registry.call('buren', :upcased)
+    registry = described_class.new(default_converters)
+    registry.register(:upcased, proc { |v| v.upcase })
+    value = registry.call('buren', :upcased)
     expect(value).to eq('BUREN')
   end
 
   it 'raises ArgumentError if an unknown type is passed' do
-    converter_registry = described_class.new(default_converters)
+    registry = described_class.new(default_converters)
     expect do
-      converter_registry.call(nil, :watman)
+      registry.call(nil, :watman)
     end.to raise_error(ArgumentError)
   end
 end

--- a/spec/honey_format/converters/converters_spec.rb
+++ b/spec/honey_format/converters/converters_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-require 'honey_format/converters/converter_registry'
-
-RSpec.describe HoneyFormat::ConverterRegistry do
+RSpec.describe HoneyFormat::Registry do
   let(:default_converters) { HoneyFormat.config.default_converters }
 
   describe 'nil type' do

--- a/spec/honey_format/converters/header_column_converter_spec.rb
+++ b/spec/honey_format/converters/header_column_converter_spec.rb
@@ -21,6 +21,7 @@ describe HoneyFormat::HeaderColumnConverter do
     ['Value (ex VAT) {SEK} [SE]', :value_ex_vat_sek_se],
     ['VAT1#', :vat1],
     ['   first_name  ', :first_name],
+    ['FirstName', :firstname],
     ['first-name', :first_name],
     ['USeRnaMe', :username],
     ['-username__-', :username],

--- a/spec/honey_format/helpers/helpers_spec.rb
+++ b/spec/honey_format/helpers/helpers_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'honey_format/helpers/helpers'
+
+RSpec.describe HoneyFormat::Helpers do
+  describe '::key_count_to_deduplicated_array' do
+    it 'converts hash data to deduplicated array' do
+      data = %i[a a b]
+      result = described_class.key_count_to_deduplicated_array(data)
+      expect(result).to eq(%i[a a1 b])
+    end
+  end
+
+  describe '::duplicated_items' do
+    it 'returns empty array if no duplicates are found' do
+      expect(described_class.duplicated_items([1, 2])).to be_empty
+    end
+
+    it 'returns duplicates in array' do
+      expect(described_class.duplicated_items([1, 2, 1])).to eq([1])
+    end
+  end
+
+  describe '::count_occurences' do
+    it 'returns empty hash for now array' do
+      expect(described_class.count_occurences([])).to be_empty
+    end
+
+    it 'returns occurrences count' do
+      expect(described_class.count_occurences(%i[a b a])).to eq(a: 2, b: 1)
+    end
+  end
+end

--- a/spec/honey_format/matrix/header_spec.rb
+++ b/spec/honey_format/matrix/header_spec.rb
@@ -78,14 +78,14 @@ describe HoneyFormat::Header do
 
       context 'raise strategy' do
         it 'raises error when duplicates are found' do
-          dep = HoneyFormat.config.default_header_deduplicator_strategies[:raise]
+          dep = HoneyFormat.config.default_header_deduplicators[:raise]
           expect do
             described_class.new(%w[first first second], deduplicator: dep)
           end.to raise_error(HoneyFormat::DuplicateHeaderColumnError)
         end
 
         it 'returns columns untouched if no duplicates are found' do
-          dep = HoneyFormat.config.default_header_deduplicator_strategies[:raise]
+          dep = HoneyFormat.config.default_header_deduplicators[:raise]
           expect do
             described_class.new(%w[first second], deduplicator: dep)
           end.not_to raise_error(HoneyFormat::DuplicateHeaderColumnError)

--- a/spec/honey_format/matrix/header_spec.rb
+++ b/spec/honey_format/matrix/header_spec.rb
@@ -78,14 +78,14 @@ describe HoneyFormat::Header do
 
       context 'raise strategy' do
         it 'raises error when duplicates are found' do
-          dep = HoneyFormat.config.default_deduplicate_header_strategies[:raise]
+          dep = HoneyFormat.config.default_header_deduplicator_strategies[:raise]
           expect do
             described_class.new(%w[first first second], deduplicator: dep)
           end.to raise_error(HoneyFormat::DuplicateHeaderColumnError)
         end
 
         it 'returns columns untouched if no duplicates are found' do
-          dep = HoneyFormat.config.default_deduplicate_header_strategies[:raise]
+          dep = HoneyFormat.config.default_header_deduplicator_strategies[:raise]
           expect do
             described_class.new(%w[first second], deduplicator: dep)
           end.not_to raise_error(HoneyFormat::DuplicateHeaderColumnError)

--- a/spec/honey_format/registry_spec.rb
+++ b/spec/honey_format/registry_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-require 'honey_format/converters/converter_registry'
-
-RSpec.describe HoneyFormat::ConverterRegistry do
+RSpec.describe HoneyFormat::Registry do
   let(:default_converters) { HoneyFormat.config.default_converters }
 
   describe '#reset!' do

--- a/spec/honey_format/registry_spec.rb
+++ b/spec/honey_format/registry_spec.rb
@@ -5,6 +5,28 @@ require 'spec_helper'
 RSpec.describe HoneyFormat::Registry do
   let(:default_converters) { HoneyFormat.config.default_converters }
 
+  describe '#type?' do
+    it 'returns false when key is invalid' do
+      registry = described_class.new
+      expect(registry.type?({})).to eq(false)
+    end
+
+    it 'returns fals when key is not present' do
+      registry = described_class.new
+      expect(registry.type?(:watman)).to eq(false)
+    end
+
+    it 'returns true when key is a Symbol and present' do
+      registry = described_class.new(default_converters)
+      expect(registry.type?(:integer)).to eq(true)
+    end
+
+    it 'returns true when key is a String and present' do
+      registry = described_class.new(default_converters)
+      expect(registry.type?('integer')).to eq(true)
+    end
+  end
+
   describe '#reset!' do
     it 'returns new instance of converter registry' do
       converter_registry = described_class.new(default_converters)

--- a/spec/honey_format/registry_spec.rb
+++ b/spec/honey_format/registry_spec.rb
@@ -29,45 +29,45 @@ RSpec.describe HoneyFormat::Registry do
 
   describe '#reset!' do
     it 'returns new instance of converter registry' do
-      converter_registry = described_class.new(default_converters)
-      converter_registry.register(:watman, proc {})
-      converter_registry.reset!
+      registry = described_class.new(default_converters)
+      registry.register(:watman, proc {})
+      registry.reset!
 
-      expect(converter_registry.type?(:watman)).to eq(false)
+      expect(registry.type?(:watman)).to eq(false)
     end
   end
 
   describe '#unregister' do
     it 'can unregister known type' do
-      converter_registry = described_class.new(default_converters)
-      converter_registry.register(:watman, proc {})
-      converter_registry.unregister(:watman)
+      registry = described_class.new(default_converters)
+      registry.register(:watman, proc {})
+      registry.unregister(:watman)
 
-      expect(converter_registry.type?(:watman)).to eq(false)
+      expect(registry.type?(:watman)).to eq(false)
     end
 
     it 'raises UnknownTypeError when trying to unregister unknown type' do
-      converter_registry = described_class.new(default_converters)
+      registry = described_class.new(default_converters)
       expect do
-        converter_registry.unregister(:watman)
+        registry.unregister(:watman)
       end.to raise_error(HoneyFormat::UnknownTypeError)
     end
   end
 
   describe '#register' do
     it 'can register type' do
-      converter_registry = described_class.new(default_converters)
-      converter_registry.register(:watman, proc {})
-      expect(converter_registry.type?(:watman)).to eq(true)
+      registry = described_class.new(default_converters)
+      registry.register(:watman, proc {})
+      expect(registry.type?(:watman)).to eq(true)
 
       # we must reset the conveter, since its global configuration
-      converter_registry.reset!
+      registry.reset!
     end
 
     it 'raises TypeExistsError when trying to register duplicated type' do
-      converter_registry = described_class.new(default_converters)
+      registry = described_class.new(default_converters)
       expect do
-        converter_registry.register(:datetime!, proc {})
+        registry.register(:datetime!, proc {})
       end.to raise_error(HoneyFormat::TypeExistsError)
     end
   end


### PR DESCRIPTION
- Renames `HoneyFormat#converter` and `Configuration#converter` to `#converter_registry`
- Add `Configuration#header_deduplicator` configuration option
- Add `Configuration#header_deduplicator_registry` configuration registry

## TODO

- [x] Allow passing `deduplication` argument to `CSV` and `Matrix` `#initialize` methods
- [x] Add documentation
  - [x] `README`
  - [x] `examples/`

Closes #36 