### PR TITLE
Draft of babosa integration

### DIFF
--- a/honey_format.gemspec
+++ b/honey_format.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3.0'
 
+  spec.add_development_dependency 'babosa'
   spec.add_development_dependency 'benchmark-ips'
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'byebug'

--- a/lib/honey_format/converters/convert_babosa.rb
+++ b/lib/honey_format/converters/convert_babosa.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+BABOSA_LOADED = begin
+                  require 'babosa'
+                  true
+                rescue LoadError
+                  false
+                end
+
+module HoneyFormat
+  # Convert to babosa or nil
+  ConvertBabosa = proc do |v|
+    unless BABOSA_LOADED
+      raise(Errors::BabosaNotLoadedError, "unable to require 'babosa' gem, please install")
+    end
+
+    return unless v
+
+    begin
+      v.to_identifier.to_ruby_method.downcase.to_sym
+    rescue Babosa::Identifier::Error
+      nil
+    end
+  end
+end

--- a/lib/honey_format/converters/converters.rb
+++ b/lib/honey_format/converters/converters.rb
@@ -5,6 +5,7 @@ require 'honey_format/converters/convert_boolean'
 require 'honey_format/converters/convert_date_and_time'
 require 'honey_format/converters/convert_number'
 require 'honey_format/converters/convert_string'
+require 'honey_format/converters/convert_babosa'
 
 module HoneyFormat
   # Convert to nil

--- a/lib/honey_format/errors.rb
+++ b/lib/honey_format/errors.rb
@@ -28,6 +28,10 @@ module HoneyFormat
     class UnknownTypeError < ArgumentError; end
     # Raised when value type already exists
     class TypeExistsError < ArgumentError; end
+
+    # Converter errors
+    # Rasied when babosa gem is not installed and converter was used
+    class BabosaNotLoadedError < ArgumentError; end
   end
 
   include Errors

--- a/spec/honey_format/converters/converter_babosa_spec.rb
+++ b/spec/honey_format/converters/converter_babosa_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe HoneyFormat::ConvertBabosa do
+  it 'can convert' do
+    babosa_string = 'my () ruby method--Name'
+    value = described_class.call(babosa_string)
+    expect(value).to eq(:my_ruby_method_name)
+  end
+
+  it 'can convert number like value' do
+    value = described_class.call('1.1')
+
+    expect(value).to eq(:'11')
+  end
+
+  it 'returns nil for empty string' do
+    value = described_class.call('')
+
+    expect(value).to be_nil
+  end
+
+  context 'when babosa gem not loaded' do
+    it 'raises ArgumentError when called' do
+      stub_const('BABOSA_LOADED', false)
+
+      expect do
+        described_class.call('')
+      end.to raise_error(HoneyFormat::Errors::BabosaNotLoadedError)
+    end
+  end
+end


### PR DESCRIPTION
__Optional integration with `babosa` gem.__

The benefit of this is that it converts non-ascii characters in a nice way, for example `väder` becomes `vader` and `garçon` becomes `garcon` (a.k.a transliteration) which is kinda hard to do reliably from scratch..

The integration is optional, for now at least, currently this gem has no external dependencies and `babosa` is being maintained(-ish) (new commits, but no release in +3 years) and is not trivial to replace.  

---

Currently named `ConvertBabosa` and converts value to "ruby method name".

## TODO

- [ ] `babosa` supports multiple conversion strategies, which of them to we support?
  + `to_ruby_method!`, `transliterate!`, `to_ascii!`, `truncate!`, ` clean!`
- [ ]  What should the converter(s) be named?

