### PR TITLE
Add support passing a callable object to Registry#call

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,15 @@ csv = HoneyFormat::CSV.new(csv_string, type_map: type_map)
 csv.rows.first.id # => 1
 ```
 
-Add your own converter
+Pass your own
+```ruby
+csv_string = "Id,Username\n1,buren"
+type_map = { username: proc { |v| v.upcase } }
+csv = HoneyFormat::CSV.new(csv_string, type_map: type_map)
+csv.rows.first.username # => "BUREN"
+```
+
+Register your own converter
 ```ruby
 HoneyFormat.configure do |config|
   config.converter_registry.register :upcased, proc { |v| v.upcase }
@@ -126,7 +134,12 @@ decimal_converter = HoneyFormat.converter_registry[:decimal]
 decimal_converter.call('1.1') # => 1.1
 ```
 
-See [`Configuration#default_converters`](https://github.com/buren/honey_format/tree/master/lib/honey_format/configuration.rb#L38) for a complete list of the default ones.
+Default converter names
+```ruby
+HoneyFormat.config.default_converters.keys
+```
+
+See [`Configuration#default_converters`](https://github.com/buren/honey_format/blob/master/lib/honey_format/configuration.rb#L99) for a complete list of the default ones.
 
 __Row builder__
 

--- a/lib/honey_format/registry.rb
+++ b/lib/honey_format/registry.rb
@@ -38,9 +38,11 @@ module HoneyFormat
     end
 
     # Call value type
-    # @param [Symbol, String] type the name of the type
+    # @param [Symbol, String, #call] type the name of the type
     # @param [Object] value to be converted
     def call(value, type)
+      return type.call(value) if type.respond_to?(:call)
+
       self[type].call(value)
     end
 

--- a/spec/honey_format/registry_spec.rb
+++ b/spec/honey_format/registry_spec.rb
@@ -83,4 +83,22 @@ RSpec.describe HoneyFormat::Registry do
       expect(described_class.new(default_converters).types).to eq(expected)
     end
   end
+
+  describe '#call' do
+    it 'calls the registered type' do
+      registry = described_class.new(default_converters)
+      expect(registry.call('1', :integer)).to eq(1)
+    end
+
+    it 'calls #call on type if passed proc' do
+      registry = described_class.new(default_converters)
+      expect(registry.call('1', proc { |v| v.to_i })).to eq(1)
+    end
+
+    it 'calls #call on type if passed object that responds to #call' do
+      registry = described_class.new(default_converters)
+      type = Class.new { define_method(:call) { |v| v.to_i } }.new
+      expect(registry.call('1', type)).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
Closes #48 

---

Enables us to pass a callable object to type map – currently you have to first register the converter and then call by name (this makes one-offs easier/less verbose).
```ruby
csv_string = "Id,User\n1,buren"
csv = HoneyFormat::CSV.new(
  csv_string,
  type_map: { user: proc { |v| v.upcase } }
)
```