### PR TITLE
Update TravisCI text matrix to test Ruby 2.6.0-preview3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,8 @@ matrix:
     install:
       - gem install bundler
       - bundle install
-  - rvm: 2.6.0-preview1
+  - rvm: 2.6.0-preview3
     install:
-      - gem install bundler
       - bundle install
   - name: TruffleRuby
     rvm: system

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,5 @@ matrix:
       - export TRUFFLERUBY_VERSION=1.0.0-rc3
       - curl -L https://github.com/oracle/truffleruby/releases/download/vm-$TRUFFLERUBY_VERSION/truffleruby-$TRUFFLERUBY_VERSION-linux-amd64.tar.gz | tar xz
       - export PATH="$PWD/truffleruby-$TRUFFLERUBY_VERSION-linux-amd64/bin:$PATH"
-      - gem install bundler --no-ri --no-rdoc
+      - gem install bundler -v 1.16.6 --no-ri --no-rdoc
       - bundle install

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ matrix:
   include:
   - rvm: 2.3.0
     install:
-      - gem install bundler
+      - gem install bundler --no-ri --no-rdoc
       - bundle install
   - rvm: 2.5.1
     install:
-      - gem install bundler
+      - gem install bundler --no-ri --no-rdoc
       - bundle install
   - rvm: 2.6.0-preview3
     install:
@@ -24,5 +24,5 @@ matrix:
       - export TRUFFLERUBY_VERSION=1.0.0-rc3
       - curl -L https://github.com/oracle/truffleruby/releases/download/vm-$TRUFFLERUBY_VERSION/truffleruby-$TRUFFLERUBY_VERSION-linux-amd64.tar.gz | tar xz
       - export PATH="$PWD/truffleruby-$TRUFFLERUBY_VERSION-linux-amd64/bin:$PATH"
-      - gem install bundler
+      - gem install bundler --no-ri --no-rdoc
       - bundle install


### PR DESCRIPTION
- TravisCI Ruby-2.6.0preview1 => Ruby-2.6.0preview3
- No need to install bundler in Ruby-2.6.0preview3, since its built in
- Specify bundler version for TruffleRuby, since its only compatible with bundler `v1.16.x` – this gets that test suite running again 🎉 