### PR TITLE
Fix type_map to allow having non present column without raising

### DIFF
--- a/lib/honey_format/matrix/row_builder.rb
+++ b/lib/honey_format/matrix/row_builder.rb
@@ -57,12 +57,24 @@ module HoneyFormat
 
       # Convert values
       @type_map.each do |column, type|
-        row[column] = @converter.call(row[column], type)
+        if row.respond_to?(column) && wrap_in_array(@columns).include?(column)
+          row[column] = @converter.call(row[column], type)
+        end
       end
 
       return row unless @builder
 
       @builder.call(row)
+    end
+
+    def wrap_in_array(object)
+      if object.nil?
+        []
+      elsif object.respond_to?(:to_ary)
+        object.to_ary || [object]
+      else
+        [object]
+      end
     end
 
     # Raises invalid row length error

--- a/spec/honey_format/matrix/row_builder_spec.rb
+++ b/spec/honey_format/matrix/row_builder_spec.rb
@@ -39,6 +39,12 @@ describe HoneyFormat::RowBuilder do
       expect(result).to eq(1)
     end
 
+    it 'does not break if type_map has a non present column' do
+      row = described_class.new(:id, type_map: { id: :integer, thing: :decimal })
+      result = row.build(['1']).id
+      expect(result).to eq(1)
+    end
+
     it 'can have spec chars column names' do
       expected = 'value'
       row = described_class.new(:ÅÄÖ)


### PR DESCRIPTION
Allow type_map to have a column that is not actually present in the CSV without breaking.