### PR TITLE
Add support for multiple type converters & Add strip converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ csv = HoneyFormat::CSV.new(csv_string, type_map: type_map)
 csv.rows.first.username # => "BUREN"
 ```
 
+Combine multiple converters
+```ruby
+csv_string = "Id,Username\n1,  BuRen  "
+type_map = { username: [:strip, :downcase] }
+csv = HoneyFormat::CSV.new(csv_string, type_map: type_map)
+csv.rows.first.username # => "buren"
+```
+
 Register your own converter
 ```ruby
 HoneyFormat.configure do |config|

--- a/examples/type_map.rb
+++ b/examples/type_map.rb
@@ -33,9 +33,9 @@ end
 
 # Map columns to types
 type_map = {
-  email: proc { |email| email.downcase }, # you pass any object that respond to #call
+  email: proc { |email| email.downcase }, # pass any object that respond to #call
   age: :integer!, # the ! version will raise an exception if the value can't be converted
-  username: [:strip, :downcase, proc { |v| "rE-#{v}" }], # you can pass an array of converts to be used
+  username: [:strip, :downcase, proc { |v| "rE-#{v}" }], # pass an array of converters
   country: :country_code,
   created_date: :date,
 }

--- a/examples/type_map.rb
+++ b/examples/type_map.rb
@@ -5,11 +5,11 @@ require 'honey_format'
 require 'date'
 
 csv_string = <<~CSV
-  email,name,age,country,created_date
-  john@example.com,John Doe,42,SE,2015-03-01
-  jane@example.com,Jane Doe,42,DK,2016-04-20
-  john1@example.com,John Doe,42,NO,2018-01-01
-  jane1@example.com,Jane Doe,42,SE,1999-01-01
+  email,username,name,age,country,created_date
+  john@example.com,  john ,John Doe,42,SE,2015-03-01
+  jane@example.com, Jane,Jane Doe,42,DK,2016-04-20
+  john1@example.com,John1 ,John Doe,42,NO,2018-01-01
+  jane1@example.com,  Jane1,Jane Doe,42,SE,1999-01-01
 CSV
 
 country_code_converter = proc { |v|
@@ -35,6 +35,7 @@ end
 type_map = {
   email: proc { |email| email.downcase }, # you pass any object that respond to #call
   age: :integer!, # the ! version will raise an exception if the value can't be converted
+  username: [:strip, :downcase, proc { |v| "rE-#{v}" }], # you can pass an array of converts to be used
   country: :country_code,
   created_date: :date,
 }

--- a/lib/honey_format/converters/convert_string.rb
+++ b/lib/honey_format/converters/convert_string.rb
@@ -10,6 +10,9 @@ module HoneyFormat
   # Convert to upcase or nil
   ConvertUpcase = proc { |v| v&.upcase }
 
+  # Convert to stripped string
+  ConvertStrip = proc { |v| v&.strip }
+
   # Convert to symbol or nil
   ConvertSymbol = proc { |v| v&.to_sym }
 
@@ -35,8 +38,13 @@ module HoneyFormat
     ConvertDowncase.call(v) || raise(ArgumentError, "can't convert nil to downcased string")
   end
 
+  # Convert to downcase or raise error
+  StrictConvertStrip = proc do |v|
+    ConvertStrip.call(v) || raise(ArgumentError, "can't convert nil to downcased string")
+  end
+
   # Convert to symbol or raise error
   StrictConvertSymbol = proc do |v|
-    ConvertSymbol.call(v) || raise(ArgumentError, "can't convert nil to symbol")
+    ConvertSymbol.call(v) || raise(ArgumentError, "can't convert nil to stripped string")
   end
 end

--- a/lib/honey_format/converters/converters.rb
+++ b/lib/honey_format/converters/converters.rb
@@ -20,6 +20,7 @@ module HoneyFormat
       symbol!: StrictConvertSymbol,
       downcase!: StrictConvertDowncase,
       upcase!: StrictConvertUpcase,
+      strip!: StrictConvertStrip,
       boolean!: StrictConvertBoolean,
       # safe variants
       decimal: ConvertDecimal,
@@ -31,6 +32,7 @@ module HoneyFormat
       symbol: ConvertSymbol,
       downcase: ConvertDowncase,
       upcase: ConvertUpcase,
+      strip: ConvertStrip,
       boolean: ConvertBoolean,
       md5: ConvertMD5,
       hex: ConvertHex,

--- a/lib/honey_format/matrix/row_builder.rb
+++ b/lib/honey_format/matrix/row_builder.rb
@@ -57,7 +57,11 @@ module HoneyFormat
 
       # Convert values
       @type_map.each do |column, type|
-        row[column] = @converter.call(row[column], type)
+        types = type.respond_to?(:each) ? type : [type]
+        value = row[column]
+        types.each { |type| value = @converter.call(value, type) }
+
+        row[column] = value
       end
 
       return row unless @builder

--- a/lib/honey_format/matrix/row_builder.rb
+++ b/lib/honey_format/matrix/row_builder.rb
@@ -59,7 +59,7 @@ module HoneyFormat
       @type_map.each do |column, type|
         types = type.respond_to?(:each) ? type : [type]
         value = row[column]
-        types.each { |type| value = @converter.call(value, type) }
+        types.each { |t| value = @converter.call(value, t) }
 
         row[column] = value
       end

--- a/spec/honey_format/converters/convert_string_spec.rb
+++ b/spec/honey_format/converters/convert_string_spec.rb
@@ -70,6 +70,40 @@ RSpec.describe HoneyFormat::StrictConvertUpcase do
   end
 end
 
+RSpec.describe HoneyFormat::ConvertStrip do
+  describe 'downcase type' do
+    it 'can convert' do
+      value = described_class.call('  buren  ', :strip)
+      expect(value).to eq('buren')
+    end
+
+    it "returns nil if value can't be converted" do
+      value = described_class.call(nil, :strip)
+      expect(value).to be_nil
+    end
+  end
+end
+
+RSpec.describe HoneyFormat::StrictConvertStrip do
+  describe 'strip! type' do
+    it 'can convert' do
+      value = described_class.call('  buren  ', :strip!)
+      expect(value).to eq('buren')
+    end
+
+    it 'can return unchanged' do
+      value = described_class.call('buren', :strip!)
+      expect(value).to eq('buren')
+    end
+
+    it "raises ArgumentError if type can't be converted" do
+      expect do
+        described_class.call(nil, :strip!)
+      end.to raise_error(ArgumentError)
+    end
+  end
+end
+
 RSpec.describe HoneyFormat::ConvertSymbol do
   describe 'symbol type' do
     it 'can convert' do

--- a/spec/honey_format/matrix/row_builder_spec.rb
+++ b/spec/honey_format/matrix/row_builder_spec.rb
@@ -93,7 +93,7 @@ describe HoneyFormat::RowBuilder do
     end
 
     it 'converts cells according to passed type map multiple types' do
-      type_map = { username: [:strip, :downcase] }
+      type_map = { username: %i[strip downcase] }
       row = described_class.new(%i(username), type_map: type_map)
       expect(row.build(['  Buren   ']).username).to eq('buren')
     end

--- a/spec/honey_format/matrix/row_builder_spec.rb
+++ b/spec/honey_format/matrix/row_builder_spec.rb
@@ -80,6 +80,29 @@ describe HoneyFormat::RowBuilder do
       expect(row.build([expected]).id).to eq(expected)
       expect(row.build([expected]).username).to eq(nil)
     end
+
+    it 'converts cells according to passed type map' do
+      row = described_class.new(%i(age), type_map: { age: :integer })
+      expect(row.build(['1']).age).to eq(1)
+    end
+
+    it 'converts cells according to passed type map with custom converter' do
+      type_map = { cost: proc { |v| v.to_i * 1.25 } }
+      row = described_class.new(%i(cost), type_map: type_map)
+      expect(row.build(['100']).cost).to eq(125)
+    end
+
+    it 'converts cells according to passed type map multiple types' do
+      type_map = { username: [:strip, :downcase] }
+      row = described_class.new(%i(username), type_map: type_map)
+      expect(row.build(['  Buren   ']).username).to eq('buren')
+    end
+
+    it 'converts cells according to passed type map multiple types with custom converter' do
+      type_map = { username: [:strip, :downcase, proc { |v| "rE-#{v}" }] }
+      row = described_class.new(%i(username), type_map: type_map)
+      expect(row.build(['  Buren   ']).username).to eq('rE-buren')
+    end
   end
 
   describe '#to_csv' do

--- a/spec/honey_format/registry_spec.rb
+++ b/spec/honey_format/registry_spec.rb
@@ -75,9 +75,9 @@ RSpec.describe HoneyFormat::Registry do
   describe '#types' do
     it 'returns the register types' do
       expected = %i[
-        decimal! integer! date! datetime! symbol! downcase! upcase! boolean!
-        decimal decimal_or_zero integer integer_or_zero
-        date datetime symbol downcase upcase boolean md5 hex nil blank
+        decimal! integer! date! datetime! symbol! downcase! upcase! strip!
+        boolean! decimal decimal_or_zero integer integer_or_zero
+        date datetime symbol downcase upcase strip boolean md5 hex nil blank
         header_column method_name
       ]
       expect(described_class.new(default_converters).types).to eq(expected)


### PR DESCRIPTION
1. Add string strip converter
2. Add support for multiple type converters
  ```ruby
  csv_string = "Id,Username\n1,  BuRen  "
  type_map = { username: [:strip, :downcase] }
  csv = HoneyFormat::CSV.new(csv_string, type_map: type_map)
  csv.rows.first.username # => "buren"
  ```